### PR TITLE
Added a helper function to prefix params with a string of '0x' to

### DIFF
--- a/lib/logstash/inputs/protocols/ethereum.rb
+++ b/lib/logstash/inputs/protocols/ethereum.rb
@@ -30,7 +30,7 @@ class EthereumProtocol < BlockchainProtocol
   public
   def get_block(height)
     # get the block data
-    block_data = make_rpc_call('eth_getBlockByNumber', height, true)
+    block_data = make_rpc_call('eth_getBlockByNumber', hexprefix(height), true)
 
     # get all transaction data
     tx_info = block_data.delete('transactions')
@@ -56,6 +56,10 @@ class EthereumProtocol < BlockchainProtocol
         data[key] = value.to_string()
       end
     end
+  end
+  
+  def hexprefix(param)
+    return '0x' + param.to_s
   end
 end
 


### PR DESCRIPTION
conform with the RPC specification here;

https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber


Tested against geth v1.6.1 and Logstash 5.4