### PR TITLE
Field type change

### DIFF
--- a/logstash-blockchain-ethereum-template.json
+++ b/logstash-blockchain-ethereum-template.json
@@ -1,5 +1,5 @@
 {
-  "template": "ethereum",
+  "template": "ethereum*",
   "mappings": {
     "block": {
       "properties": {
@@ -58,7 +58,7 @@
           "type": "long"
         },
         "totalDifficulty": {
-          "type": "long"
+          "type": "keyword"
         },
         "transactionsRoot": {
           "type": "keyword"
@@ -176,7 +176,7 @@
               "type": "long"
             },
             "totalDifficulty": {
-              "type": "long"
+              "type": "keyword"
             },
             "transactionsRoot": {
               "type": "keyword"


### PR DESCRIPTION
Changed type of totalDifficulty field from long to keyword as it frequently was too large to be parsed as a long and generates a warning of;

19:07:25.665 [[main]>worker3] WARN  logstash.outputs.elasticsearch 
- Failed action. {:status=>400, :action=>["index", {:_id=>"ccc15885a4fe5781f77a2b47ceaad2c24be3a5a25bf9bc1e503811e07058d6d8", 
:_index=>"ethereum-testnet-2016.03.12", :_type=>"logs", :_routing=>nil}, 2016-03-12T22:41:26.000Z %{host} %{message}], 
:response=>{"index"=>{"_index"=>"ethereum-testnet-2016.03.12", "_type"=>"logs", "_id"=>"ccc15885a4fe5781f77a2b47ceaad2c24be3a5a25bf9bc1e503811e07058d6d8", "status"=>400, "error"=>{"type"=>"mapper_parsing_exception", 
"reason"=>"failed to parse [block.totalDifficulty]", "caused_by"=>{"type"=>"number_format_exception", "reason"=>"For input string: \"9232213882011903515\""}}}}}

I think this also causes type conflict warning messages in Kibana too.
